### PR TITLE
add file upload to the SDK

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies

--- a/.github/workflows/npm_deploy.yaml
+++ b/.github/workflows/npm_deploy.yaml
@@ -11,9 +11,9 @@ jobs:
     environment: production
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ console.log(data.mediaId);
 ## Upload Media
 
 Function that adds a media to the Secure Redact system. The mediaPath must be a presigned URL that the Secure Redact system can download the file from.
+To upload a file directly use the File parameter to pass in a File object and pass in an empty string for the mediaPath.
 
 You can monitor progress in two ways. Either by polling our /info route (see [Fetch Media Status](#fetch-media-status)) or by setting up the stateCallback URL. This must be a URL where the Secure Redact system can POST updates to. For more information see the [API reference](https://docs.secureredact.co.uk/#3a149f82-27ae-4673-a7f4-17cc28d8c146)
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,23 @@
+# How to use
+
+1. git clone https://github.com/pimloc/secure-redact-javascript-sdk
+
+2. Open the repo in VSCode
+
+3. Log into your SecureRedact account (https://app.secureredact.co.uk/ or https://app.secureredact.us)
+
+4. From the top right click on your user name (or dashboard button if you have an enterprise account)
+
+5. Click on the API Credentials.
+
+6. Click on the "New Credential" button
+
+7. Replace the clientId and client Secret in the index.html
+
+8. Right click the demo/index.html and select "Open with live server". You will need to install the extension "live server".
+
+9. The page should open in the browser
+
+10. Select a file to upload, the video will be uploaded to your account.
+
+11. You will see the video in the application (https://app.secureredact.co.uk/ or https://app.secureredact.us)

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SecureRedactSDK Demo</title>
+</head>
+<body>
+  <input type="file" id="fileInput" accept="video/*">
+  <button onclick="uploadFile()">Upload</button>
+
+  <script type="module">
+    import { SecureRedactSDK } from '../dist/SecureRedactSDK.js';
+    const clientId = 'your-client-id';
+    const clientSecret = 'your-client-secret';
+    const url = 'https://app.secureredact.co.uk';
+    const sdk = new SecureRedactSDK({clientId, clientSecret, url});
+
+    window.uploadFile = async function() {
+      const fileInput = document.getElementById('fileInput');
+      const file = fileInput.files[0];
+
+      if (!file) {
+        alert('Please select a file to upload');
+        return;
+      }
+
+      try {
+        const res = await sdk.uploadMedia({
+            mediaPath: '',
+            videoTag: 'test',
+            increasedDetectionAccuracy: false,
+            detectLicensePlates: true,
+            detectFaces: true,
+            file: file
+        });
+        console.log(res);
+
+        // while the video is still processing, you can check the status
+        let status = await sdk.fetchMediaStatus({
+          mediaId: res.mediaId
+        });
+        while (status.status !== 'detected') {
+          console.log(`Video is still processing... ${status.status}`);
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          status = await sdk.fetchMediaStatus({
+            mediaId: res.mediaId
+          });
+        }
+
+        status = await sdk.redactMedia({
+          mediaId: res.mediaId,
+          enlargeBoxes: '0.05',
+          redactAudio: 'false',
+          blur: 'smooth'
+         });
+
+        // wait for video to be redacted
+        status = await sdk.fetchMediaStatus({
+          mediaId: res.mediaId
+        });
+        while (status.status !== 'exported' && status.status !== 'completed') {
+          console.log(`Video is still processing... ${status.status}`);
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          status = await sdk.fetchMediaStatus({
+            mediaId: res.mediaId
+          });
+        }
+
+        // download the redacted video
+        let data = await sdk.downloadMedia({
+          mediaId: res.mediaId
+        });
+        console.log('Video downloaded:');
+        let url = URL.createObjectURL(data.blob);
+        let video = document.createElement('video');
+        video.src = url;
+        video.controls = true;
+        document.body.appendChild(video);
+        video.play();
+      } catch (error) {
+        console.error('Error processing file:', error);
+      }
+    }
+  </script>
+</body>
+</html>

--- a/lib/SecureRedactRequest.ts
+++ b/lib/SecureRedactRequest.ts
@@ -10,7 +10,7 @@ class SecureRedactRequest {
     blob?: Blob
   ): Promise<SecureRedactResponse> => {
     try {
-      let outHeaders: Record<string, string> = {
+      const outHeaders: Record<string, string> = {
         Accept: 'application/json',
         Authorization: auth
       };

--- a/lib/SecureRedactRequest.ts
+++ b/lib/SecureRedactRequest.ts
@@ -10,18 +10,18 @@ class SecureRedactRequest {
     blob?: Blob
   ): Promise<SecureRedactResponse> => {
     try {
-      let aheaders: Record<string, string> = {
-        'Accept': 'application/json',
-        'Authorization': auth
-      }
+      let outHeaders: Record<string, string> = {
+        Accept: 'application/json',
+        Authorization: auth
+      };
       for (const key in headers) {
         if (headers[key] !== undefined && headers[key] !== null) {
-          aheaders[key] = headers[key];
+          outHeaders[key] = headers[key];
         }
       }
       let body = null;
       if (blob) {
-        aheaders['Content-Type'] = 'multipart/form-data';
+        outHeaders['Content-Type'] = 'multipart/form-data';
         body = new FormData();
         body.append('file', blob);
         const obj = SecureRedactRequest.convertObjectToSnake(data);
@@ -31,10 +31,10 @@ class SecureRedactRequest {
       } else {
         body = SecureRedactRequest.buildBody(data);
       }
-    
+
       return await SecureRedactRequest.makeRequest(url, {
         method: 'POST',
-        headers: aheaders,
+        headers: outHeaders,
         body: body
       });
     } catch (err) {

--- a/lib/SecureRedactRequest.ts
+++ b/lib/SecureRedactRequest.ts
@@ -7,7 +7,7 @@ class SecureRedactRequest {
     data: SecureRedactParams,
     auth: string,
     headers?: Record<string, string>,
-    blob?: Blob
+    videoBlob?: Blob
   ): Promise<SecureRedactResponse> => {
     try {
       const outHeaders: Record<string, string> = {
@@ -20,16 +20,16 @@ class SecureRedactRequest {
         }
       }
       let body = null;
-      if (blob) {
-        outHeaders['Content-Type'] = 'multipart/form-data';
+      if (videoBlob) {
         body = new FormData();
-        body.append('file', blob);
+        body.append('video', videoBlob);
         const obj = SecureRedactRequest.convertObjectToSnake(data);
         for (const key in obj) {
           body.append(key, obj[key]?.toString() ?? '');
         }
       } else {
         body = SecureRedactRequest.buildBody(data);
+        outHeaders['Content-Type'] = 'application/json';
       }
 
       return await SecureRedactRequest.makeRequest(url, {

--- a/lib/SecureRedactSDK.ts
+++ b/lib/SecureRedactSDK.ts
@@ -318,7 +318,7 @@ class SecureRedactSDK {
     file = undefined
   }: SecureRedactUploadMediaParams): Promise<SecureRedactUploadResponse> => {
     let data: SecureRedactResponse;
-    if (mediaPath) {
+    if (!mediaPath) {
       // send file as chunks of data
       data = await this.#sendChunks({
         mediaPath,

--- a/lib/SecureRedactSDK.ts
+++ b/lib/SecureRedactSDK.ts
@@ -122,7 +122,13 @@ class SecureRedactSDK {
     );
   };
 
-  #loadChunk = (chunkIndex: number, totalChunks: number, fileSize: number, reader: FileReader, file: File) => {
+  #loadChunk = (
+    chunkIndex: number,
+    totalChunks: number,
+    fileSize: number,
+    reader: FileReader,
+    file: File
+  ) => {
     return new Promise((resolve, reject) => {
       const numBytes =
         totalChunks === 1 ? fileSize : this.#CHUNK_SIZE * 1000 * 1000;
@@ -159,7 +165,7 @@ class SecureRedactSDK {
   ) => {
     return await this.#makeAuthenticatedPostRequest(
       this.#buildUrlPath(SecureRedactEndpoints.UPLOAD_MEDIA),
-      { 
+      {
         mediapath: params.mediaPath,
         videoTag: params.videoTag,
         increasedDetectionAccuracy: params.increasedDetectionAccuracy,
@@ -177,26 +183,28 @@ class SecureRedactSDK {
       },
       chunk
     );
-  }
+  };
 
-  #sendChunks = async (
-    params: SecureRedactUploadMediaParams
-  ) => {
+  #sendChunks = async (params: SecureRedactUploadMediaParams) => {
     const file = params.file;
     if (!file) {
       throw new SecureRedactError('No file provided', 400);
     }
 
-    let reader = new FileReader(); 
+    const reader = new FileReader();
     let fileId: any = '';
-    const totalChunks = Math.ceil(
-      file.size / (this.#CHUNK_SIZE * 1000 * 1000)
-    );
+    const totalChunks = Math.ceil(file.size / (this.#CHUNK_SIZE * 1000 * 1000));
 
     let data: SecureRedactResponse = {};
 
     for (let i = 0; i < totalChunks; i++) {
-      const chunk: any = await this.#loadChunk(i, totalChunks, file.size, reader, file);
+      const chunk: any = await this.#loadChunk(
+        i,
+        totalChunks,
+        file.size,
+        reader,
+        file
+      );
       const fileData: Blob = chunk.data;
       data = await this.#sendChunk(params, fileData, i, totalChunks, fileId);
       if (!fileId) {
@@ -205,7 +213,7 @@ class SecureRedactSDK {
     }
 
     return data;
-  }
+  };
 
   fetchToken = async ({
     username
@@ -307,8 +315,7 @@ class SecureRedactSDK {
     faces = true,
     file = undefined
   }: SecureRedactUploadMediaParams): Promise<SecureRedactUploadResponse> => {
-
-    let data : SecureRedactResponse;
+    let data: SecureRedactResponse;
     if (mediaPath) {
       // send file as chunks of data
       data = await this.#sendChunks({
@@ -336,8 +343,8 @@ class SecureRedactSDK {
           faces
         }
       );
-      }
-    
+    }
+
     if (typeof data.mediaId !== 'string') {
       throw new SecureRedactError('Invalid media_id type returned', 500);
     }

--- a/lib/SecureRedactSDK.ts
+++ b/lib/SecureRedactSDK.ts
@@ -192,12 +192,14 @@ class SecureRedactSDK {
     }
 
     const reader = new FileReader();
+    // @typescript-eslint/no-explicit-any
     let fileId: any = '';
     const totalChunks = Math.ceil(file.size / (this.#CHUNK_SIZE * 1000 * 1000));
 
     let data: SecureRedactResponse = {};
 
     for (let i = 0; i < totalChunks; i++) {
+      // @typescript-eslint/no-explicit-any
       const chunk: any = await this.#loadChunk(
         i,
         totalChunks,

--- a/lib/SecureRedactSDK.ts
+++ b/lib/SecureRedactSDK.ts
@@ -26,7 +26,7 @@ import {
 } from './types/internal.js';
 
 class SecureRedactSDK {
-  readonly #BASE_URL: string = 'https://app.secureredact.co.uk';
+  #BASE_URL: string = 'https://app.secureredact.co.uk';
   readonly #VERSION: string = 'v2';
   readonly #MAX_RETRIES: number = 1;
   readonly #CHUNK_SIZE: number = 10;
@@ -35,11 +35,14 @@ class SecureRedactSDK {
 
   constructor({
     clientId,
-    clientSecret
+    clientSecret,
+    url = 'https://app.secureredact.co.uk'
   }: {
     clientId: string;
     clientSecret: string;
+    url?: string; // Add the 'url' property to the type definition
   }) {
+    this.#BASE_URL = url;
     this.#basicToken = buildBasicToken(clientId, clientSecret);
     this.#bearerToken = null;
   }

--- a/lib/SecureRedactSDK.ts
+++ b/lib/SecureRedactSDK.ts
@@ -192,14 +192,14 @@ class SecureRedactSDK {
     }
 
     const reader = new FileReader();
-    // @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let fileId: any = '';
     const totalChunks = Math.ceil(file.size / (this.#CHUNK_SIZE * 1000 * 1000));
 
     let data: SecureRedactResponse = {};
 
     for (let i = 0; i < totalChunks; i++) {
-      // @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const chunk: any = await this.#loadChunk(
         i,
         totalChunks,

--- a/lib/__tests__/uploadMedia.test.ts
+++ b/lib/__tests__/uploadMedia.test.ts
@@ -27,7 +27,9 @@ const requestParams: SecureRedactUploadMediaParams = {
   increasedDetectionAccuracy: true,
   stateCallback: 'http://example.com/state',
   exportCallback: 'http://example.com/export',
-  exportToken: 'random_token'
+  exportToken: 'random_token',
+  faces: true,
+  licensePlates: false
 };
 const validResponse = {
   fileInfo: {
@@ -143,7 +145,9 @@ describe('test uploadMedia functionality', () => {
       increased_detection_accuracy: requestParams.increasedDetectionAccuracy,
       state_callback: requestParams.stateCallback,
       export_callback: requestParams.exportCallback,
-      export_token: requestParams.exportToken
+      export_token: requestParams.exportToken,
+      faces: true,
+      license_plates: false
     });
   });
 });

--- a/lib/__tests__/uploadMedia.test.ts
+++ b/lib/__tests__/uploadMedia.test.ts
@@ -146,8 +146,8 @@ describe('test uploadMedia functionality', () => {
       state_callback: requestParams.stateCallback,
       export_callback: requestParams.exportCallback,
       export_token: requestParams.exportToken,
-      faces: true,
-      license_plates: false
+      detect_faces: true,
+      detect_license_plates: false
     });
   });
 });

--- a/lib/__tests__/uploadMedia.test.ts
+++ b/lib/__tests__/uploadMedia.test.ts
@@ -28,8 +28,8 @@ const requestParams: SecureRedactUploadMediaParams = {
   stateCallback: 'http://example.com/state',
   exportCallback: 'http://example.com/export',
   exportToken: 'random_token',
-  faces: true,
-  licensePlates: false
+  detectFaces: true,
+  detectLicensePlates: false
 };
 const validResponse = {
   fileInfo: {

--- a/lib/types/internal.ts
+++ b/lib/types/internal.ts
@@ -37,7 +37,7 @@ interface SecureRedactParams
     Partial<SecureRedactRedactMediaParams>,
     Partial<SecureRedactUploadMediaParams>,
     Partial<SecureRedactDownloadMediaParams> {
-  [key: string]: string | number | boolean | undefined | null;
+  [key: string]: string | number | boolean | File | undefined | null;
 }
 
 interface SecureRedactResponse

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -45,6 +45,9 @@ interface SecureRedactUploadMediaParams {
   stateCallback?: string;
   exportCallback?: string;
   exportToken?: string;
+  licensePlates?: boolean;
+  faces?: boolean;
+  file?: File;
 }
 
 interface SecureRedactUploadResponse {

--- a/lib/types/lib.ts
+++ b/lib/types/lib.ts
@@ -45,8 +45,8 @@ interface SecureRedactUploadMediaParams {
   stateCallback?: string;
   exportCallback?: string;
   exportToken?: string;
-  licensePlates?: boolean;
-  faces?: boolean;
+  detectLicensePlates?: boolean;
+  detectFaces?: boolean;
   file?: File;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@secure-redact/javascript-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@secure-redact/javascript-sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {
         "@tsconfig/node20": "^20.1.0",


### PR DESCRIPTION
# Objective

- Adds the option to pass in a File object to the UploadMedia so a file can be uploaded directly from local file storage without needing a download_url.
- Adds a demo folder with a simple index.html to show usage to upload, redact and download media.

## PR type

- [ ] Bug Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Other

## PR checklist

- [x] Have you self reviewed your code?
- [x] Have you verified that the changes you've made fulfil the objective of this PR?
- [ ] Do your commits follow the commit guidelines?
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Do all pre-existing tests pass?
- [x] Docs have been added / updated (for bug fixes / features)

## Changelog

### Added

* Added file upload to the UploadMedia function, such a local file can be uploaded through the API.
* Added options to control if faces and license plates are redacted as part of the UploadMedia
